### PR TITLE
Extended write method to clear title and line properties after writin…

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -178,8 +178,7 @@ class Log
 
         $this->writeInLog();
 
-        $this->title = null;
-        $this->line  = '';
+        $this->clearInput();
 
         return true;
     }
@@ -240,6 +239,15 @@ class Log
     private function loadLogger()
     {
         $this->log = new Writer(new Logger($this->loggerName));
+    }
+
+    /**
+     * Clear title and line
+     */
+    protected function clearInput()
+    {
+        $this->title = '';
+        $this->line = '';
     }
 
 }

--- a/src/Log.php
+++ b/src/Log.php
@@ -178,6 +178,9 @@ class Log
 
         $this->writeInLog();
 
+        $this->title = null;
+        $this->line  = '';
+
         return true;
     }
 


### PR DESCRIPTION
I found your project because I wanted to log to a separate log file for all my queue job class handle methods, as a way of helping me debug some queue issues. I noticed, when the queue handler is running, that the logged lines kept growing every time the handler created and wrote a log to the log file via your Log::write method.

The fix is to extend the write method to reset the title and line properties to their initial, empty state each time write is called.  This way, each time the queue worker handles a queued job, the log entry isn't still carrying title and line data from the previous call.
